### PR TITLE
Fix CI: pin pnpm via packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "engines": {
     "node": ">=24"
   },
+  "packageManager": "pnpm@10.17.0",
   "type": "module",
   "main": "dist/index.mjs",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,29 +9,29 @@ importers:
   .:
     dependencies:
       '@google-cloud/spanner':
-        specifier: ^8.6.0
+        specifier: 8.6.0
         version: 8.6.0
       '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
+        specifier: 1.29.0
         version: 1.29.0(zod@4.3.6)
       zod:
-        specifier: ^4.3.6
+        specifier: 4.3.6
         version: 4.3.6
     devDependencies:
       '@types/node':
-        specifier: ^25.6.0
+        specifier: 25.6.0
         version: 25.6.0
       tsdown:
-        specifier: ^0.21.9
+        specifier: 0.21.9
         version: 0.21.9(typescript@6.0.3)
       tsx:
-        specifier: ^4.21.0
+        specifier: 4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^6.0.3
+        specifier: 6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.4
+        specifier: 4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
@@ -1951,7 +1951,7 @@ snapshots:
       '@babel/helpers': 7.27.6
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.27.7
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 2.0.0
       debug: 4.4.3


### PR DESCRIPTION
## Summary
- CI `build` job was failing at the `Setup pnpm` step with `No pnpm version is specified`. Added `"packageManager": "pnpm@10.17.0"` to `package.json` so `pnpm/action-setup` can resolve the version.
- Refreshed `pnpm-lock.yaml` so its specifiers match the exact-pinned versions in `package.json` (prevents the follow-on `ERR_PNPM_OUTDATED_LOCKFILE` under `--frozen-lockfile`).

## Test plan
- [x] `pnpm install --frozen-lockfile` locally
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm run test`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)