### PR TITLE
Reset version baseline to 0.0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "readonly-spanner",
   "description": "Read-only Google Cloud Spanner MCP server. Exposes SELECT-only query execution and schema introspection (list_tables, describe_table, list_indexes, execute_query). Write operations are blocked by both a forbidden-keyword regex and a Spanner read-only snapshot.",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "author": {
     "name": "nu0ma",
     "url": "https://github.com/nu0ma"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spanner-readonly-mcp",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Read-only MCP server for Google Cloud Spanner",
   "license": "MIT",
   "author": "nu0ma",


### PR DESCRIPTION
## Summary
- Downgrade baseline version from 1.0.0 to 0.0.1 in both \`package.json\` and \`.claude-plugin/plugin.json\`
- Next \`Create Release PR\` (patch) will cut 0.0.2 as the first published release

## Context
PR #2 bumped to v1.0.1, but this package has never been published to npm and should start at 0.0.x. Closing that PR and re-baselining here.

## Test plan
- [ ] Merge, then trigger \`Create Release PR\` → expect \`release/v0.0.2\` PR