### PR TITLE
Fix repo rename fallout and sync plugin manifest version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "readonly-spanner",
   "description": "Read-only Google Cloud Spanner MCP server. Exposes SELECT-only query execution and schema introspection (list_tables, describe_table, list_indexes, execute_query). Write operations are blocked by both a forbidden-keyword regex and a Spanner read-only snapshot.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "nu0ma",
     "url": "https://github.com/nu0ma"
   },
-  "homepage": "https://github.com/nu0ma/readonly-spanner-mcp",
-  "repository": "https://github.com/nu0ma/readonly-spanner-mcp",
+  "homepage": "https://github.com/nu0ma/spanner-readonly-mcp",
+  "repository": "https://github.com/nu0ma/spanner-readonly-mcp",
   "license": "MIT",
   "keywords": [
     "spanner",

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -51,6 +51,18 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
+      - name: Sync plugin manifest version
+        env:
+          VERSION: ${{ env.VERSION }}
+        run: |
+          node -e "
+            const fs = require('fs');
+            const path = '.claude-plugin/plugin.json';
+            const m = JSON.parse(fs.readFileSync(path, 'utf8'));
+            m.version = process.env.VERSION;
+            fs.writeFileSync(path, JSON.stringify(m, null, 2) + '\n');
+          "
+
       - name: Get release notes
         id: release-notes
         env:

--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@ pnpm build
 
 ## Usage
 
-### Claude Code Plugin (recommended)
+### Claude Code Plugin
 
-This repo ships as a Claude Code plugin. Install from this GitHub repo directly:
+This repo is packaged as a Claude Code plugin. Until submission to the official marketplace is approved, install locally:
 
 ```bash
-/plugin marketplace add nu0ma/readonly-spanner-mcp
-/plugin install readonly-spanner@readonly-spanner-mcp
+git clone https://github.com/nu0ma/spanner-readonly-mcp
+claude --plugin-dir ./spanner-readonly-mcp
 ```
 
-Then set the required env vars (see below) in your shell before launching Claude Code. The plugin launches the server via `npx -y spanner-readonly-mcp@latest`.
+The plugin launches the server via `npx -y spanner-readonly-mcp@latest`; set `SPANNER_PROJECT` / `SPANNER_INSTANCE` / `SPANNER_DATABASE` in your shell before starting Claude Code.
 
 ### Claude Desktop
 

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Read-only MCP server for Google Cloud Spanner",
   "license": "MIT",
   "author": "nu0ma",
-  "homepage": "https://github.com/nu0ma/readonly-spanner-mcp",
+  "homepage": "https://github.com/nu0ma/spanner-readonly-mcp",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nu0ma/readonly-spanner-mcp.git"
+    "url": "git+https://github.com/nu0ma/spanner-readonly-mcp.git"
   },
-  "bugs": "https://github.com/nu0ma/readonly-spanner-mcp/issues",
+  "bugs": "https://github.com/nu0ma/spanner-readonly-mcp/issues",
   "keywords": [
     "mcp",
     "spanner",


### PR DESCRIPTION
## Summary
- Update all URLs from \`readonly-spanner-mcp\` to \`spanner-readonly-mcp\` after the GitHub repo rename. This unblocks \`npm publish --provenance\` which was rejected with a repository-URL mismatch against the OIDC claim during the v0.0.2 release.
- Sync \`.claude-plugin/plugin.json\` version to 0.0.2 (it was stuck at 0.0.1 because \`npm version\` only touches \`package.json\`).
- Patch \`create-release-pr.yaml\` to bump the plugin manifest version alongside \`package.json\` so this never drifts again.
- Replace the broken \`/plugin marketplace add nu0ma/readonly-spanner-mcp\` instructions in README with a working \`--plugin-dir\` local install, since this repo doesn't ship a \`marketplace.json\` yet.

## Context
- Failed release run: https://github.com/nu0ma/spanner-readonly-mcp/actions/runs/24596993541
- npm error: \`Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: \"repository.url\" is \"git+https://github.com/nu0ma/readonly-spanner-mcp.git\", expected to match \"https://github.com/nu0ma/spanner-readonly-mcp\" from provenance\`

## Next steps after merge
1. Manually dispatch \`Release\` workflow with version \`0.0.2\` (tag doesn't exist yet, so it will retry the publish), OR
2. Run \`Create Release PR → patch\` to cut 0.0.3 instead and skip 0.0.2 entirely.

## Test plan
- [ ] CI passes on this branch
- [ ] After merge, \`Release\` workflow succeeds and 0.0.x appears on https://www.npmjs.com/package/spanner-readonly-mcp