### PR TITLE
Report the real package version to MCP clients

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,15 @@
+import { readFileSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Database } from "@google-cloud/spanner";
 import { z } from "zod";
+
+// Resolved at runtime from the installed package's package.json so the
+// version reported to MCP clients matches what npm actually shipped.
+const PACKAGE_VERSION = (
+  JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8")
+  ) as { version: string }
+).version;
 
 // Leading-whitespace class includes ASCII \s plus BOM, NBSP, and zero-width
 // spaces (U+200B..U+200D), which some clients prepend to slip past naive guards.
@@ -56,7 +65,7 @@ async function readOnlyQuery(
 export function createServer(database: Database): McpServer {
   const server = new McpServer({
     name: "spanner-readonly",
-    version: "1.0.0",
+    version: PACKAGE_VERSION,
   });
 
   server.tool(


### PR DESCRIPTION
## Summary
- \`McpServer\` was hardcoded to report \`serverInfo.version: "1.0.0"\`, but the published package is now \`0.0.3\`.
- Read the version from \`package.json\` at module load using a path resolved relative to \`import.meta.url\`, so the bundle in \`dist/\` picks up whatever version npm actually shipped.

## Why runtime reads and not a build-time constant?
Using \`new URL("../package.json", import.meta.url)\` lets the version track \`npm version\` bumps without any bundler-side templating. \`package.json\` is always present in an npm install, so the read always succeeds.

## Test plan
- [ ] CI green (typecheck + build + vitest)
- [ ] After merge + release, \`npx -y spanner-readonly-mcp@latest\` initialize response contains the current version