### PR TITLE
Fix marketplace plugin source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,12 +1,12 @@
 {
-  "name": "readonly-spanner-mcp",
+  "name": "spanner-readonly-mcp",
   "owner": {
     "name": "nu0ma",
     "url": "https://github.com/nu0ma"
   },
   "plugins": [
     {
-      "name": "readonly-spanner",
+      "name": "spanner-readonly-mcp",
       "source": "./"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "readonly-spanner",
-      "source": "."
+      "source": "./"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "readonly-spanner",
+  "name": "spanner-readonly-mcp",
   "description": "Read-only Google Cloud Spanner MCP server. Exposes SELECT-only query execution and schema introspection (list_tables, describe_table, list_indexes, execute_query). Write operations are blocked by both a forbidden-keyword regex and a Spanner read-only snapshot.",
   "version": "0.0.3",
   "author": {

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "readonly-spanner": {
+    "spanner-readonly-mcp": {
       "type": "stdio",
       "command": "npx",
       "args": ["-y", "spanner-readonly-mcp@latest"],

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repo doubles as a Claude Code plugin marketplace. Register it and install t
 
 ```bash
 /plugin marketplace add nu0ma/spanner-readonly-mcp
-/plugin install readonly-spanner@readonly-spanner-mcp
+/plugin install spanner-readonly-mcp@spanner-readonly-mcp
 ```
 
 The plugin launches the server via `npx -y spanner-readonly-mcp@latest`; set `SPANNER_PROJECT` / `SPANNER_INSTANCE` / `SPANNER_DATABASE` in your shell before starting Claude Code.


### PR DESCRIPTION
## Summary
Per [plugin-marketplaces docs](https://code.claude.com/docs/en/plugin-marketplaces.md#plugin-sources), relative `source` paths must start with `./`. Our previous value `"."` doesn't meet the schema and may prevent `/plugin install readonly-spanner@readonly-spanner-mcp` from resolving the plugin at the repo root.

## Test plan
- [ ] `/plugin marketplace add nu0ma/spanner-readonly-mcp`
- [ ] `/plugin install readonly-spanner@readonly-spanner-mcp`