### PR TITLE
build: minify tsdown output and bump target to node24

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -4,7 +4,8 @@ export default defineConfig({
   entry: ["src/index.ts"],
   outDir: "dist",
   format: "esm",
-  target: "node18",
+  target: "node24",
   banner: { js: "#!/usr/bin/env node" },
   clean: true,
+  minify: true,
 });


### PR DESCRIPTION
## Summary
- Enable tsdown minification.
- Bump the build target from `node18` to `node24` to match the `engines` field in `package.json`.

## Impact
- Bundle size: 4577 → 3339 bytes (gzip 1.55KB).
- Deps remain external (not bundled), so the win is bounded to our own ~160 LOC of source.
- Trade-off: minified stack traces are harder to read. Acceptable for a small CLI server distributed via `npx`.

## Test plan
- [x] `pnpm build` succeeds, shebang preserved at top of `dist/index.mjs`.
- [x] Minified bundle starts cleanly via `node dist/index.mjs` (server announces ready on stderr).
- [x] `pnpm typecheck` passes.
- [x] `pnpm test` passes (36/36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)