### PR TITLE
docs: README accuracy pass + license audit findings

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026
+Copyright (c) 2026 nu0ma
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ pnpm dev             # run from source without building
 pnpm test            # vitest, starts the Spanner emulator via docker compose
 ```
 
-Direct execution against a real Spanner instance:
+Direct execution against a real Spanner instance (build first, then run):
 
 ```bash
+pnpm build
 SPANNER_PROJECT=my-project \
 SPANNER_INSTANCE=my-instance \
 SPANNER_DATABASE=my-database \

--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ This repo doubles as a Claude Code plugin marketplace. Register it and install t
 
 The plugin launches the server via `npx -y spanner-readonly-mcp@latest`. Claude Code will prompt for `SPANNER_PROJECT`, `SPANNER_INSTANCE`, and `SPANNER_DATABASE` on install and persist them to `settings.json`.
 
-### Claude Desktop
+### Claude Code (without the plugin)
 
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS):
+Create `.mcp.json` at your project root:
 
 ```json
 {
   "mcpServers": {
-    "spanner": {
+    "spanner-readonly-mcp": {
+      "type": "stdio",
       "command": "npx",
       "args": ["-y", "spanner-readonly-mcp@latest"],
       "env": {
@@ -57,25 +58,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 }
 ```
 
-### Claude Code
-
-Add to `~/.claude/settings.json`:
-
-```json
-{
-  "mcpServers": {
-    "spanner": {
-      "command": "npx",
-      "args": ["-y", "spanner-readonly-mcp@latest"],
-      "env": {
-        "SPANNER_PROJECT": "my-project",
-        "SPANNER_INSTANCE": "my-instance",
-        "SPANNER_DATABASE": "my-database"
-      }
-    }
-  }
-}
-```
+Claude Code picks this up on session start and prompts to approve the server on first launch.
 
 ## Tools
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -26,7 +26,7 @@ gcloud auth application-default login
 
 ## 使い方
 
-### Claude Code プラグイン (推奨)
+### Claude Code プラグイン
 
 このリポジトリはそのまま Claude Code プラグインマーケットプレイスとして機能します。以下でマーケットプレイスを登録してプラグインをインストールします:
 
@@ -37,14 +37,15 @@ gcloud auth application-default login
 
 プラグインは `npx -y spanner-readonly-mcp@latest` でサーバーを起動します。インストール時に `SPANNER_PROJECT` / `SPANNER_INSTANCE` / `SPANNER_DATABASE` を聞かれ、`settings.json` に保存されます。
 
-### Claude Desktop
+### Claude Code (プラグイン以外)
 
-`~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) に以下を追加します:
+プロジェクトルートに `.mcp.json` を作成します:
 
 ```json
 {
   "mcpServers": {
-    "spanner": {
+    "spanner-readonly-mcp": {
+      "type": "stdio",
       "command": "npx",
       "args": ["-y", "spanner-readonly-mcp@latest"],
       "env": {
@@ -57,25 +58,7 @@ gcloud auth application-default login
 }
 ```
 
-### Claude Code
-
-`~/.claude/settings.json` に以下を追加します:
-
-```json
-{
-  "mcpServers": {
-    "spanner": {
-      "command": "npx",
-      "args": ["-y", "spanner-readonly-mcp@latest"],
-      "env": {
-        "SPANNER_PROJECT": "my-project",
-        "SPANNER_INSTANCE": "my-instance",
-        "SPANNER_DATABASE": "my-database"
-      }
-    }
-  }
-}
-```
+Claude Code はセッション起動時に自動で認識し、初回起動時に承認プロンプトを出します。
 
 ## ツール
 
@@ -90,10 +73,12 @@ gcloud auth application-default login
 
 IAM 認証情報に書き込み権限があっても、書き込みはブロックされます。2 層で強制しています:
 
-1. **アプリケーション層（ベストエフォート）**: INSERT / UPDATE / UPSERT / DELETE / MERGE / DDL / DCL などの変更系キーワードを、Spanner に到達する前に正規表現で拒否します。これは早期失敗のための利便性であり、**セキュリティ境界ではありません**。コメント・CTE・括弧などでペイロードを書き換えれば容易に回避できます。
-2. **トランザクション層（本質的な保証）**: すべてのクエリは Spanner の[読み取り専用スナップショットトランザクション](https://cloud.google.com/spanner/docs/transactions#read-only_transactions) (`database.getSnapshot()`) 内で実行されます。Snapshot クラスは DML メソッドを公開しておらず、Spanner バックエンドも読み取り専用トランザクション内での変更操作を拒否します。**こちらが実効的な保証層です。**
+1. **アプリケーション層 (UX、ベストエフォート)**: INSERT / UPDATE / UPSERT / DELETE / MERGE / DDL / DCL などの変更系キーワードを、Spanner に到達する前に正規表現で拒否します。エージェントが誤って変更系クエリを投げた際に分かりやすいエラーを即座に返すためのもので、**セキュリティ境界ではありません**。コメント・CTE・括弧などでペイロードを書き換えれば容易に回避できます。
+2. **トランザクション層 (本質的な保証)**: すべてのクエリは Spanner の[読み取り専用スナップショットトランザクション](https://cloud.google.com/spanner/docs/transactions#read-only_transactions) (`database.getSnapshot()`) 内で実行されます。Snapshot クラスは DML メソッドを公開しておらず、Spanner バックエンドも読み取り専用トランザクション内での変更操作を拒否します。**こちらが実効的な保証層です。**
 
-クライアントに返すエラーメッセージはサニタイズされます（1 行目のみ、`REGEX_BLOCKED:` または `SPANNER_ERROR:` プレフィックス付き）。スタックトレースや内部パスは漏洩しません。
+すべてのスナップショットクエリ (メタデータ系ツール含む) は、worst-case レイテンシを抑えるため 30 秒の `gaxOptions.timeout` を指定して実行されます。
+
+クライアントに返すエラーメッセージはサニタイズされます (1 行目のみ、`REGEX_BLOCKED:` または `SPANNER_ERROR:` プレフィックス付き)。スタックトレースや内部パスは漏洩しません。
 
 ### IAM 最小権限
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -93,9 +93,10 @@ pnpm dev             # ビルドせずにソースから実行
 pnpm test            # vitest (docker compose で Spanner emulator を起動)
 ```
 
-実 Spanner に対して直接実行する場合:
+実 Spanner に対して直接実行する場合 (先に build が必要):
 
 ```bash
+pnpm build
 SPANNER_PROJECT=my-project \
 SPANNER_INSTANCE=my-instance \
 SPANNER_DATABASE=my-database \


### PR DESCRIPTION
Documentation-only PR that fixes concrete defects found during a README accuracy audit and a dependency-license audit.

## What's wrong today

1. **`~/.claude/settings.json` doesn't accept an `mcpServers` field.** The Claude Code settings schema explicitly rejects it (\"Unrecognized field: mcpServers\"). The README's \"Claude Code\" snippet was silently wrong — anyone following it got nothing.
2. **Redundant Claude Desktop section.** The plugin install flow is the documented happy path; the raw-JSON snippet for Claude Desktop duplicated information already conveyed by the env-var table.
3. **`docs/README.ja.md` was behind `README.md`** by two content updates from #16:
   - The \"UX, best-effort\" framing on the regex layer + the sentence explaining its purpose.
   - The 30-second `gaxOptions.timeout` paragraph.
   It also still had the stale Claude Desktop + settings.json sections.
4. **`LICENSE` header** was `Copyright (c) 2026` with no copyright holder. Standard MIT header expects one.
5. **\"Direct execution\" snippet** used `pnpm start` without mentioning that `dist/index.mjs` must exist first. Silently fails in a clean checkout.

## What this PR changes

- Drops the Claude Desktop section (EN + JA).
- Replaces the broken Claude Code `settings.json` block with a `.mcp.json`-at-project-root block (EN + JA). This is what Claude Code actually reads and auto-discovers.
- Brings `docs/README.ja.md` to full parity with `README.md`.
- Sets the LICENSE copyright holder to `nu0ma`.
- Adds `pnpm build` ahead of `pnpm start` in the Direct Execution snippet (EN + JA).

## Dependency-license audit (summary)

Ran `pnpm licenses list --prod --json` against the full transitive closure (257 unique packages). Breakdown:

| License | Packages |
|---|---:|
| MIT | 187 |
| Apache-2.0 | 27 |
| ISC | 22 |
| BSD-3-Clause | 14 |
| BlueOak-1.0.0 | 4 |
| BSD-2-Clause | 2 |
| CC-BY-4.0 | 1 (caniuse-lite, pulled via `@google-cloud/spanner` → `@babel/core` → `browserslist`) |

No GPL / LGPL / AGPL / SSPL. All permissive.

Our three direct runtime deps:
- `@modelcontextprotocol/sdk` — MIT
- `@google-cloud/spanner` — Apache-2.0
- `zod` — MIT

**We do not bundle any of these into `dist/index.mjs`** (verified — the file starts with `import` statements from each package; npm resolves them at the consumer). So we are not redistributing Apache-2.0 / CC-BY-4.0 code and incur no NOTICE / attribution obligations beyond what the LICENSE file already covers.

**Conclusion: MIT remains appropriate. No license change or NOTICE file needed.**

## Follow-ups not in this PR

- The README's \"to bound worst-case latency\" wording on the `gaxOptions.timeout` is technically unverified — on the local Spanner emulator, even a 1 ms timeout lets `SELECT 1` run past 15 s, so the option doesn't enforce a deadline on the streaming RPC path there. Whether real Cloud Spanner enforces it is an open question. Not changed here because the wording is reasonable for the intended (real Spanner) target; worth a separate follow-up to verify or qualify.
- The regex keyword list in the read-only guarantee section is summarized as \"INSERT, UPDATE, UPSERT, DELETE, MERGE, and DDL/DCL\" but the actual pattern also covers `RENAME`, `ANALYZE`, and `CALL`. Minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)