### PR TITLE
fix: add required type and title to plugin userConfig

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,12 +19,18 @@
   ],
   "userConfig": {
     "SPANNER_PROJECT": {
+      "type": "string",
+      "title": "Spanner Project",
       "description": "GCP project ID"
     },
     "SPANNER_INSTANCE": {
+      "type": "string",
+      "title": "Spanner Instance",
       "description": "Spanner instance ID"
     },
     "SPANNER_DATABASE": {
+      "type": "string",
+      "title": "Spanner Database",
       "description": "Spanner database ID"
     }
   }


### PR DESCRIPTION
## Summary
- Plugin install failed manifest validation (issue #22) because each `userConfig` entry was missing the required `type` and `title` fields.
- Declares `type: string` and a human-readable `title` for `SPANNER_PROJECT`, `SPANNER_INSTANCE`, `SPANNER_DATABASE`.

Fixes #22

## Test plan
- [ ] Install the plugin locally and confirm the manifest passes validation.
- [ ] Verify the config prompts show the new titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)