### PR TITLE
chore: add inspect script for interactive MCP debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "dev": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "inspect": "npx @modelcontextprotocol/inspector node dist/index.mjs"
   },
   "dependencies": {
     "@google-cloud/spanner": "8.6.0",


### PR DESCRIPTION
## Summary
Adds `pnpm inspect` which launches [MCP Inspector](https://github.com/modelcontextprotocol/inspector) against the built server.

This is an **interactive debugging helper**, not an automated test. Use it to poke at tool definitions and responses by hand during development. Automated E2E coverage continues to live in `test/e2e.test.ts` (run via `pnpm test`).

## Usage
\`\`\`sh
docker compose up -d
pnpm build
SPANNER_EMULATOR_HOST=localhost:9010 \\
  SPANNER_PROJECT=test-project \\
  SPANNER_INSTANCE=test-instance \\
  SPANNER_DATABASE=test-db \\
  pnpm inspect
\`\`\`

## Test plan
- [ ] Run \`pnpm inspect\` locally and confirm the four tools (list_tables, describe_table, list_indexes, execute_query) appear in the Inspector UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)