### PR TITLE
Enforce row limit and expose query params on execute_query

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,8 @@ const PACKAGE_VERSION: string =
     : "0.0.0-dev";
 
 export const QUERY_TIMEOUT_MS = 30000;
+export const MAX_ROWS = 10000;
+const MAX_IDENTIFIER_LEN = 128;
 
 // Leading-whitespace class includes ASCII \s plus BOM, NBSP, and zero-width
 // spaces (U+200B..U+200D), which some clients prepend to slip past naive guards.
@@ -27,6 +29,12 @@ class RegexBlockedError extends Error {
   }
 }
 
+class RowLimitExceededError extends Error {
+  constructor() {
+    super(`ROW_LIMIT_EXCEEDED: Query returned more than ${MAX_ROWS} rows. Narrow the query or add LIMIT.`);
+  }
+}
+
 function ok(data: unknown) {
   return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
 }
@@ -37,6 +45,7 @@ function fail(msg: string) {
 
 function sanitize(error: unknown): string {
   if (error instanceof RegexBlockedError) return error.message;
+  if (error instanceof RowLimitExceededError) return error.message;
   const msg = error instanceof Error ? error.message : String(error);
   // Strip file paths, stack frames, and anything after the first newline to
   // avoid leaking internal details via error messages.
@@ -92,8 +101,20 @@ async function readOnlyQuery(
       ...(params ? { params } : {}),
       gaxOptions: { timeout: QUERY_TIMEOUT_MS },
     };
-    const [rows] = await snapshot.run(query);
-    return rows.map(serializeRow);
+    const rows: unknown[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const stream = snapshot.runStream(query);
+      stream.on("data", (row: unknown) => {
+        if (rows.length >= MAX_ROWS) {
+          stream.destroy(new RowLimitExceededError());
+          return;
+        }
+        rows.push(serializeRow(row));
+      });
+      stream.on("end", () => resolve());
+      stream.on("error", (err) => reject(err));
+    });
+    return rows;
   } finally {
     snapshot.end();
   }
@@ -128,7 +149,12 @@ export function createServer(database: Database): McpServer {
   server.tool(
     "describe_table",
     "Get schema information (columns, types, nullability) for a specific table",
-    { table_name: z.string().describe("Name of the table to describe") },
+    {
+      table_name: z
+        .string()
+        .max(MAX_IDENTIFIER_LEN)
+        .describe("Name of the table to describe"),
+    },
     async ({ table_name }) => {
       try {
         const columns = await readOnlyQuery(
@@ -158,6 +184,7 @@ export function createServer(database: Database): McpServer {
     {
       table_name: z
         .string()
+        .max(MAX_IDENTIFIER_LEN)
         .optional()
         .describe("Table name to list indexes for. Omit to list all indexes."),
     },
@@ -185,10 +212,19 @@ export function createServer(database: Database): McpServer {
     "Execute a read-only SQL query (SELECT only) against the Spanner database",
     {
       sql: z.string().describe("SQL SELECT query to execute"),
+      params: z
+        .record(
+          z.string(),
+          z.union([z.string(), z.number(), z.boolean(), z.null()])
+        )
+        .optional()
+        .describe(
+          "Named parameter bindings (e.g. {userId: 'u1'}) referenced as @userId in sql. Prefer this over string interpolation."
+        ),
     },
-    async ({ sql }) => {
+    async ({ sql, params }) => {
       try {
-        const results = await readOnlyQuery(database, sql);
+        const results = await readOnlyQuery(database, sql, params);
         return ok({ row_count: results.length, rows: results });
       } catch (error) {
         return fail(sanitize(error));

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Spanner } from "@google-cloud/spanner";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createServer, QUERY_TIMEOUT_MS } from "../src/server.js";
+import { createServer, QUERY_TIMEOUT_MS, MAX_ROWS } from "../src/server.js";
 import type { Database, Instance } from "@google-cloud/spanner";
 
 const PROJECT_ID = "test-project";
@@ -521,6 +521,59 @@ describe("row serialization", () => {
   });
 });
 
+describe("execute_query with params", () => {
+  it("binds named parameters instead of string interpolation", async () => {
+    const result = await client.callTool({
+      name: "execute_query",
+      arguments: {
+        sql: "SELECT name FROM Users WHERE user_id = @uid",
+        params: { uid: "u1" },
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = parseContent(result);
+    expect(data.row_count).toBe(1);
+    expect(data.rows[0].name).toBe("Alice");
+  });
+
+  it("treats parameter values as data, not SQL (injection attempt is inert)", async () => {
+    const result = await client.callTool({
+      name: "execute_query",
+      arguments: {
+        sql: "SELECT name FROM Users WHERE user_id = @uid",
+        params: { uid: "u1' OR '1'='1" },
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = parseContent(result);
+    expect(data.row_count).toBe(0);
+  });
+});
+
+describe("row limit enforcement", () => {
+  it("rejects queries returning more than MAX_ROWS", async () => {
+    const result = await client.callTool({
+      name: "execute_query",
+      arguments: {
+        sql: `SELECT n FROM UNNEST(GENERATE_ARRAY(1, ${MAX_ROWS + 5})) AS n`,
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(errorText(result)).toMatch(/^ROW_LIMIT_EXCEEDED:/);
+  });
+
+  it("allows queries at exactly MAX_ROWS", async () => {
+    const result = await client.callTool({
+      name: "execute_query",
+      arguments: {
+        sql: `SELECT n FROM UNNEST(GENERATE_ARRAY(1, ${MAX_ROWS})) AS n`,
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(parseContent(result).row_count).toBe(MAX_ROWS);
+  });
+});
+
 describe("query timeout", () => {
   it("passes the configured gaxOptions timeout on every snapshot.run query", async () => {
     const realGetSnapshot = database.getSnapshot.bind(database);
@@ -528,10 +581,10 @@ describe("query timeout", () => {
 
     (database as any).getSnapshot = async (...args: any[]) => {
       const [snapshot] = await realGetSnapshot(...(args as []));
-      const realRun = snapshot.run.bind(snapshot);
-      (snapshot as any).run = async (query: any) => {
+      const realRunStream = snapshot.runStream.bind(snapshot);
+      (snapshot as any).runStream = (query: any) => {
         capturedQuery = query;
-        return realRun(query);
+        return realRunStream(query);
       };
       return [snapshot];
     };


### PR DESCRIPTION
## Summary
- Cap `execute_query` results at `MAX_ROWS` (10000) via `snapshot.runStream` + early `stream.destroy()`, so oversized result sets never fully materialize in memory. Prevents DoS / mass data exfiltration through the MCP surface.
- Expose optional `params` on `execute_query` (`Record<string, string|number|boolean|null>`) so callers can use named bindings (`@foo`) instead of string interpolation. Mitigates prompt-injection-driven SELECT SQLi even though the read-only guard already blocks DML/DDL.
- Cap `describe_table` / `list_indexes` `table_name` arguments at 128 chars via Zod.
- New `RowLimitExceededError` is surfaced as `ROW_LIMIT_EXCEEDED: …` through the existing `sanitize` path.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 47/47 pass, including:
  - [x] `execute_query with params`: named binding works; `"u1' OR '1'='1"` is treated as a literal (0 rows)
  - [x] `row limit enforcement`: `GENERATE_ARRAY(1, MAX_ROWS+5)` → `ROW_LIMIT_EXCEEDED`; exactly `MAX_ROWS` → allowed
  - [x] Existing `query timeout` test updated to intercept `runStream` instead of `run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)