### PR TITLE
feat: optional SPANNER_EMULATOR_HOST plugin userConfig

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -32,6 +32,11 @@
       "type": "string",
       "title": "Spanner Database",
       "description": "Spanner database ID"
+    },
+    "SPANNER_EMULATOR_HOST": {
+      "type": "string",
+      "title": "Spanner Emulator Host (optional)",
+      "description": "Set to host:port (e.g. 127.0.0.1:9010) to point at a local Spanner emulator instead of real Cloud Spanner. Leave blank for production."
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,7 +7,8 @@
       "env": {
         "SPANNER_PROJECT": "${user_config.SPANNER_PROJECT}",
         "SPANNER_INSTANCE": "${user_config.SPANNER_INSTANCE}",
-        "SPANNER_DATABASE": "${user_config.SPANNER_DATABASE}"
+        "SPANNER_DATABASE": "${user_config.SPANNER_DATABASE}",
+        "SPANNER_EMULATOR_HOST": "${user_config.SPANNER_EMULATOR_HOST}"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The server reads these at runtime (the Claude Code plugin prompts for them on in
 | `SPANNER_PROJECT` | Yes | GCP project ID |
 | `SPANNER_INSTANCE` | Yes | Spanner instance ID |
 | `SPANNER_DATABASE` | Yes | Spanner database ID |
+| `SPANNER_EMULATOR_HOST` | No | `host:port` (e.g. `127.0.0.1:9010`) to point at a local Spanner emulator. Leave unset for production. |
 
 ## Usage
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -23,6 +23,7 @@ gcloud auth application-default login
 | `SPANNER_PROJECT` | はい | GCP プロジェクト ID |
 | `SPANNER_INSTANCE` | はい | Spanner インスタンス ID |
 | `SPANNER_DATABASE` | はい | Spanner データベース ID |
+| `SPANNER_EMULATOR_HOST` | いいえ | `host:port` (例 `127.0.0.1:9010`) を指定するとローカル Spanner emulator に向く。本番では未設定のまま。 |
 
 ## 使い方
 


### PR DESCRIPTION
## Summary
Add `SPANNER_EMULATOR_HOST` as an optional Claude Code plugin `userConfig` field, so users can point the plugin-installed server at a local Spanner emulator without bypassing the plugin.

## Why
Today the plugin's `userConfig` exposes only `SPANNER_PROJECT` / `SPANNER_INSTANCE` / `SPANNER_DATABASE`. There is no plumbed-through way to set `SPANNER_EMULATOR_HOST` for the spawned `npx` subprocess. To test the plugin against an emulator, users have to either:

- Export `SPANNER_EMULATOR_HOST` in the shell before launching Claude Code and rely on env inheritance reaching the MCP child (fragile, undocumented, varies by client).
- Bypass the plugin entirely via a project-scoped `.mcp.json` with hard-coded values.

Both are friction. This PR adds the field as an optional plugin option and threads it through `.mcp.json`'s env mapping.

## Implementation
- `.claude-plugin/plugin.json`: new optional `SPANNER_EMULATOR_HOST` userConfig (`type: string`, `title: \"Spanner Emulator Host (optional)\"`).
- `.mcp.json`: added to the `env` mapping as `${user_config.SPANNER_EMULATOR_HOST}`.
- README + README.ja: documented in the env-vars table as optional.

The Spanner Node SDK already honours `SPANNER_EMULATOR_HOST` natively, so no source change is needed.

## Test plan
- [x] `pnpm build` succeeds.
- [x] Local smoke: `SPANNER_EMULATOR_HOST=127.0.0.1:9010 SPANNER_PROJECT=… node dist/index.mjs` stays alive (server announces ready, exits 0 on SIGTERM).
- [ ] After release: `/plugin install` shows the new field; entering `127.0.0.1:9010` plus emulator-side project/instance/database makes `/mcp` show the server as connected; `list_tables` / `execute_query` against seeded emulator data return correct rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)