### PR TITLE
ci: route pnpm installs through Takumi Guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
-          # cache: pnpm  # TEMP: disabled to verify Takumi Guard proxy actually fetches packages
+          cache: pnpm
 
       - name: Setup Takumi Guard
         uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -30,6 +31,9 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+
+      - name: Setup Takumi Guard
+        uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
-          cache: pnpm
+          # cache: pnpm  # TEMP: disabled to verify Takumi Guard proxy actually fetches packages
 
       - name: Setup Takumi Guard
         uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -34,6 +35,9 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+
+      - name: Setup Takumi Guard
+        uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,6 +84,10 @@ jobs:
           git add package.json
           echo "✅ Updated package.json to v${VERSION}"
 
+      - name: Setup Takumi Guard
+        if: steps.tag-check.outputs.exists == 'false'
+        uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+
       - name: Install dependencies
         if: steps.tag-check.outputs.exists == 'false'
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Add `flatt-security/setup-takumi-guard-npm` to `ci.yaml`, `release.yaml`, and `create-release-pr.yaml` so every `pnpm install` is routed through `npm.flatt.tech`, blocking known-malicious packages before they execute.
- Pinned to `v1.1.1` by commit SHA (`9a5d797c2085b6326d3a2985c08e3a114b9b88c1`), matching the repo's existing SHA-pinning convention.
- Add `id-token: write` to `ci.yaml` and `create-release-pr.yaml` (required by Takumi Guard's OIDC auth). `release.yaml` already had it.

## Why

Inbound supply-chain defense, complementary to the outbound `npm publish --provenance` already in place. `--provenance` signs what we publish; Takumi Guard inspects what we install.

Running in blocking-only mode (no `bot-id`). Audit-logging can be enabled later by passing `bot-id` once a Flatt account is registered.

## Test plan

- [ ] CI workflow runs successfully on this PR
- [ ] `pnpm install` output shows the Takumi Guard registry is in use
- [ ] No regressions in typecheck / build / test steps