### PR TITLE
chore(deps): bundle MCP SDK and zod into dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,15 +49,15 @@
     "inspect": "pnpm exec @modelcontextprotocol/inspector node dist/index.mjs"
   },
   "dependencies": {
-    "@google-cloud/spanner": "8.6.0",
-    "@modelcontextprotocol/sdk": "1.29.0",
-    "zod": "4.3.6"
+    "@google-cloud/spanner": "8.6.0"
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@types/node": "25.6.0",
     "tsdown": "0.21.9",
     "tsx": "4.21.0",
     "typescript": "6.0.3",
-    "vitest": "4.1.4"
+    "vitest": "4.1.4",
+    "zod": "4.3.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,13 +11,10 @@ importers:
       '@google-cloud/spanner':
         specifier: 8.6.0
         version: 8.6.0
+    devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@4.3.6)
-      zod:
-        specifier: 4.3.6
-        version: 4.3.6
-    devDependencies:
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -33,6 +30,9 @@ importers:
       vitest:
         specifier: 4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
 
 packages:
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
   banner: { js: "#!/usr/bin/env node" },
   clean: true,
   minify: true,
+  deps: {
+    alwaysBundle: ["@modelcontextprotocol/sdk", "zod"],
+  },
   define: {
     __SPANNER_MCP_VERSION__: JSON.stringify(pkg.version),
   },


### PR DESCRIPTION
## Summary
- Reduce runtime `dependencies` from 3 → 1 by bundling `@modelcontextprotocol/sdk` and `zod` via tsdown's `deps.alwaysBundle`.
- `@google-cloud/spanner` stays external (grpc + runtime `.proto` loading makes bundling brittle).
- Bundle size: 334 kB (gzip 88.67 kB).

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (47/47 E2E tests against Spanner emulator)
- [x] `pnpm exec @modelcontextprotocol/inspector --cli node dist/index.mjs --method tools/list` lists all 4 tools (`list_tables`, `describe_table`, `list_indexes`, `execute_query`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)