### PR TITLE
chore: export rulesets as reusable JSON

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,24 @@
+# Rulesets
+
+Reusable GitHub ruleset definitions. Apply to any repo with:
+
+```sh
+# Create new ruleset
+gh api -X POST repos/OWNER/REPO/rulesets --input .github/rulesets/protect-main.json
+
+# Update existing ruleset (needs ruleset id)
+gh api -X PUT repos/OWNER/REPO/rulesets/RULESET_ID --input .github/rulesets/protect-main.json
+```
+
+## Files
+
+| File | Target | Purpose |
+|---|---|---|
+| `protect-main.json` | default branch | Block delete/force-push/creation, require PR (conversation resolution), require `build` + `actionlint` status checks (strict) |
+| `protect-release-tags.json` | `refs/tags/v*` | Block delete / update / non-fast-forward on release tags. Tag creation allowed so release workflow can publish. |
+
+## Notes
+
+- `protect-main.json` requires status checks named `build` and `actionlint`. Rename in the file if your workflow job names differ.
+- No `required_signatures` — keeps CLI commits from CI (e.g. tag creation) working. Remove this caveat once your release flow signs commits.
+- No `bypass_actors` — nothing can skip these rules, including the repo owner.

--- a/.github/rulesets/protect-main.json
+++ b/.github/rulesets/protect-main.json
@@ -1,0 +1,56 @@
+{
+    "bypass_actors": [],
+    "conditions": {
+        "ref_name": {
+            "exclude": [],
+            "include": [
+                "~DEFAULT_BRANCH"
+            ]
+        }
+    },
+    "enforcement": "active",
+    "name": "protect main",
+    "rules": [
+        {
+            "type": "deletion"
+        },
+        {
+            "type": "non_fast_forward"
+        },
+        {
+            "type": "creation"
+        },
+        {
+            "parameters": {
+                "allowed_merge_methods": [
+                    "merge",
+                    "squash",
+                    "rebase"
+                ],
+                "dismiss_stale_reviews_on_push": true,
+                "require_code_owner_review": false,
+                "require_last_push_approval": false,
+                "required_approving_review_count": 0,
+                "required_review_thread_resolution": true,
+                "required_reviewers": []
+            },
+            "type": "pull_request"
+        },
+        {
+            "parameters": {
+                "do_not_enforce_on_create": false,
+                "required_status_checks": [
+                    {
+                        "context": "build"
+                    },
+                    {
+                        "context": "actionlint"
+                    }
+                ],
+                "strict_required_status_checks_policy": true
+            },
+            "type": "required_status_checks"
+        }
+    ],
+    "target": "branch"
+}

--- a/.github/rulesets/protect-release-tags.json
+++ b/.github/rulesets/protect-release-tags.json
@@ -1,0 +1,25 @@
+{
+    "bypass_actors": [],
+    "conditions": {
+        "ref_name": {
+            "exclude": [],
+            "include": [
+                "refs/tags/v*"
+            ]
+        }
+    },
+    "enforcement": "active",
+    "name": "protect release tags",
+    "rules": [
+        {
+            "type": "deletion"
+        },
+        {
+            "type": "update"
+        },
+        {
+            "type": "non_fast_forward"
+        }
+    ],
+    "target": "tag"
+}


### PR DESCRIPTION
## Summary
- Export \`protect main\` and \`protect release tags\` rulesets to \`.github/rulesets/\`
- Add README with \`gh api\` apply commands for reuse on other repos

## Test plan
- [ ] Apply to a scratch repo via \`gh api -X POST repos/OWNER/REPO/rulesets --input protect-main.json\`
- [ ] Confirm rules match source repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)