### PR TITLE
ci: use GitHub App token for release PR creation

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -21,11 +21,19 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.4
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -92,6 +100,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           branch: release/v${{ env.VERSION }}
           delete-branch: true
           title: "Release v${{ env.VERSION }}"


### PR DESCRIPTION
## Summary
- Swap default \`GITHUB_TOKEN\` for a GitHub App token in \`create-release-pr.yaml\`
- Enables downstream \`pull_request\` workflows (CI, actionlint) to run on release PRs, satisfying required status checks

## Why
PRs authored by the default \`GITHUB_TOKEN\` do not trigger cascaded workflows (documented GitHub behavior). With required status checks \`build\` + \`actionlint\` now enforced on \`main\`, release PRs were stuck forever at "Expected — Waiting for status to be reported".

## Required repo secrets
- \`RELEASE_APP_ID\`
- \`RELEASE_APP_PRIVATE_KEY\`

## Test plan
- [ ] Re-run \`Create Release PR\` workflow
- [ ] Confirm new release PR has \`build\` and \`actionlint\` reporting status
- [ ] Confirm the PR author is the GitHub App, not \`github-actions[bot]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)