### PR TITLE
fix: pin publish registry to npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "LICENSE"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
     "build": "tsdown",


### PR DESCRIPTION
## Summary
- Add \`publishConfig.registry: https://registry.npmjs.org/\` to \`package.json\`

## Why
Release workflow failed with:
\`\`\`
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://npm.flatt.tech/
\`\`\`
Ref: https://github.com/nu0ma/spanner-readonly-mcp/actions/runs/24626572044

Root cause: the repo-level \`.npmrc\` sets \`registry=https://npm.flatt.tech/\` to route installs through the Takumi Guard proxy. Without a publish-time override, \`npm publish\` also targets that registry. Trusted publishing is set up on npmjs.org, so the publish fails with ENEEDAUTH.

\`publishConfig.registry\` takes precedence for publish commands only, so installs keep flowing through Takumi Guard as intended.

## Test plan
- [ ] Re-run release (\`workflow_dispatch\` Release with version \`0.0.10\`, or merge a new release PR)
- [ ] Confirm publish succeeds to npmjs.org with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)