### PR TITLE
chore: pin onlyBuiltDependencies in pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - esbuild
+  - protobufjs


### PR DESCRIPTION
## Summary
- Check in `pnpm-workspace.yaml` so the `onlyBuiltDependencies` approval for `esbuild` and `protobufjs` is shared across contributors. pnpm v10 requires explicit opt-in for postinstall scripts; without this file, each contributor is prompted separately.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds without the interactive prompt once the file is committed