### PR TITLE
ci: adopt npm staged publishing for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,10 +109,9 @@ jobs:
           cache: pnpm
 
       # Node 24 bundles an npm older than 11.15.0, which `npm stage publish`
-      # requires. Pin to ^11.15.0 to stay below v12 (where --allow-git flips
-      # to none by default).
+      # requires. Pin to an exact version for reproducible releases.
       - name: Ensure npm supports staged publishing
-        run: npm install -g npm@^11.15.0
+        run: npm install -g npm@11.15.0
 
       - name: Update package.json version
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,6 +108,12 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
 
+      # Node 24 bundles an npm older than 11.15.0, which `npm stage publish`
+      # requires. Pin to ^11.15.0 to stay below v12 (where --allow-git flips
+      # to none by default).
+      - name: Ensure npm supports staged publishing
+        run: npm install -g npm@^11.15.0
+
       - name: Update package.json version
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
         env:
@@ -143,8 +149,12 @@ jobs:
           fi
           echo "✅ Build verification successful"
 
-      - name: Publish to npm via trusted publishing
-        run: npm publish --provenance --access public
+      # Stage the publish instead of releasing directly. The tarball lands in
+      # npm's stage queue; a maintainer must approve it with 2FA via
+      # `npm stage approve <id>` or npmjs.com before it becomes installable.
+      # Requires the trusted publisher on npmjs.com to allow `npm stage`.
+      - name: Stage publish to npm via trusted publishing
+        run: npm stage publish --provenance --access public
 
       - name: Create and push tag
         env:
@@ -206,10 +216,12 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: |
           gh pr comment "${PR_NUMBER}" \
-            --body "✅ **Release v${VERSION} completed successfully!**
+            --body "🟡 **Release v${VERSION} staged — awaiting maintainer approval**
 
-          - 📦 npm install: \`npm install ${PACKAGE_NAME}@${VERSION}\`
-          - 📦 npm package: https://www.npmjs.com/package/${PACKAGE_NAME}/v/${VERSION}
+          The package is in npm's stage queue. A maintainer must approve it with 2FA before it becomes installable:
+          - ✅ Approve: \`npm stage approve\` (or via the stage queue on npmjs.com)
+          - 📦 After approval — npm install: \`npm install ${PACKAGE_NAME}@${VERSION}\`
+          - 📦 After approval — npm package: https://www.npmjs.com/package/${PACKAGE_NAME}/v/${VERSION}
           - 🏷️ GitHub Release: ${RELEASE_URL}
           - 🔗 Workflow run: ${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
 


### PR DESCRIPTION
Adopts staged publishing from https://github.blog/changelog/2026-05-22-staged-publishing-and-new-install-time-controls-for-npm/.

## Changes (`.github/workflows/release.yaml`)

- Pin npm to `11.15.0` (required by `npm stage publish`; Node 24 bundles an older npm).
- Use `npm stage publish` instead of `npm publish`. The package goes to npm's stage queue and a maintainer approves it with 2FA before it's live.
- Update the PR success comment to say the release is staged and awaiting approval.

## Note

Needs the npmjs.com trusted publisher to allow `npm stage` (won't work otherwise). After each release, a maintainer must run `npm stage approve <stage-id>` or approve on npmjs.com.
