### PR TITLE
chore: pin .mcp.json to an exact version

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,7 @@
     "spanner-readonly-mcp": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "spanner-readonly-mcp@latest"],
+      "args": ["-y", "spanner-readonly-mcp@0.0.11"],
       "env": {
         "SPANNER_PROJECT": "${user_config.SPANNER_PROJECT}",
         "SPANNER_INSTANCE": "${user_config.SPANNER_INSTANCE}",


### PR DESCRIPTION
Replaces the `@latest` tag in `.mcp.json` with an exact version (`0.0.11`).

`@latest` makes `npx` resolve whatever is newest at runtime, so the MCP server's behavior can change without any change in this repo. Pinning to an exact version gives a reproducible, known build.

`0.0.11` is the current latest published version.
