### PR TITLE
ci: auto-sync .mcp.json pinned version on release

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -75,6 +75,27 @@ jobs:
             fs.writeFileSync(path, JSON.stringify(m, null, 2) + '\n');
           "
 
+      - name: Sync .mcp.json pinned version
+        env:
+          VERSION: ${{ env.VERSION }}
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const path = '.mcp.json';
+            const cfg = JSON.parse(fs.readFileSync(path, 'utf8'));
+            const server = cfg.mcpServers[pkg.name];
+            server.args = server.args.map((a) =>
+              a === pkg.name || a.startsWith(pkg.name + '@')
+                ? pkg.name + '@' + process.env.VERSION
+                : a
+            );
+            fs.writeFileSync(path, JSON.stringify(cfg, null, 2) + '\n');
+          "
+          # .mcp.json is at the repo root, so biome formats it (unlike the
+          # nested plugin.json). Re-format so the release PR passes `pnpm lint`.
+          pnpm exec biome format --write .mcp.json
+
       - name: Get release notes
         id: release-notes
         env:

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,7 @@
     "spanner-readonly-mcp": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "spanner-readonly-mcp@latest"],
+      "args": ["-y", "spanner-readonly-mcp@0.0.11"],
       "env": {
         "SPANNER_PROJECT": "${user_config.SPANNER_PROJECT}",
         "SPANNER_INSTANCE": "${user_config.SPANNER_INSTANCE}",


### PR DESCRIPTION
Auto-syncs the pinned version in `.mcp.json` to the bumped `package.json` version, so the exact pin landed in #49 stays current without manual edits.

## Change (`.github/workflows/create-release-pr.yaml`)

Adds a `Sync .mcp.json pinned version` step (mirrors the existing `plugin.json` sync) that:
- rewrites the `spanner-readonly-mcp@<version>` arg to the version `npm version` just bumped to, targeting only the `mcpServers` entry (not the JSON keys);
- runs `biome format --write .mcp.json` afterward — `.mcp.json` is at the repo root so biome formats it (unlike the nested `plugin.json`), and this keeps the release PR passing `pnpm lint`.

The synced `.mcp.json` is committed into the release PR opened by this workflow, so it's reviewed and merged like any other change — no push-back to `main`.

## Testing

- `actionlint` passes.
- Simulated the node edit + biome format locally (e.g. 0.0.11 → 0.0.12): diff is the version only, and `biome check` passes.
