### PR TITLE
ci: sign release PR commits (verified) so they pass main's ruleset

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -101,6 +101,10 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # Create the commit via the GitHub API so it is signed (verified).
+          # main's ruleset requires verified signatures; a plain git push from
+          # the action produces an unsigned commit that can't be merged.
+          sign-commits: true
           branch: release/v${{ env.VERSION }}
           delete-branch: true
           title: "Release v${{ env.VERSION }}"


### PR DESCRIPTION
## Why

`main`'s ruleset requires **verified signatures** (`required_signatures`). `peter-evans/create-pull-request` pushes the release-bump commit with a plain git push, which is **unsigned** — so the generated Release PR (e.g. #54) is blocked with "Commits must have verified signatures" and can't be merged.

## Change (`.github/workflows/create-release-pr.yaml`)

Set `sign-commits: true` on the create-pull-request step. The action then creates the commit via the GitHub API, which GitHub signs, so the commit is verified and satisfies the ruleset.

## Note

This fixes future release PRs. The already-open #54 has an unsigned commit and is handled separately (re-signed).
