### PR TITLE
ci: fix npm stage publish blocked by allow-directory=none

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -152,8 +152,13 @@ jobs:
       # npm's stage queue; a maintainer must approve it with 2FA via
       # `npm stage approve <id>` or npmjs.com before it becomes installable.
       # Requires the trusted publisher on npmjs.com to allow `npm stage`.
+      #
+      # --allow-directory=all overrides the repo .npmrc (allow-directory=none,
+      # set for install-source hardening): publishing packs the current dir as
+      # a "directory" spec, which that setting otherwise blocks with
+      # EALLOWDIRECTORY. The override is scoped to this publish command only.
       - name: Stage publish to npm via trusted publishing
-        run: npm stage publish --provenance --access public
+        run: npm stage publish --provenance --access public --allow-directory=all
 
       - name: Create and push tag
         env:


### PR DESCRIPTION
## Why

The v0.0.12 release (#56) failed at the **Stage publish** step:

```
npm error code EALLOWDIRECTORY
npm error Fetching packages of type "directory" have been disabled
```

The repo `.npmrc` sets `allow-directory=none` (install-source hardening from #50). But `npm stage publish` packs the current directory as a `"directory"` spec, which that setting blocks. So the two npm-supply-chain changes collide: the install restriction breaks publishing.

## Fix (`.github/workflows/release.yaml`)

Add `--allow-directory=all` to the `npm stage publish` command. A CLI flag overrides `.npmrc`, so it re-enables directory packing **for the publish command only** — the `allow-directory=none` install hardening stays in effect everywhere else.

## State after the failed run

- No `v0.0.12` tag was created (the job failed before tagging), and nothing was staged/published (npm latest is still `0.0.11`), so re-releasing `0.0.12` is not blocked.

## Re-release after merge

Trigger the **Release** workflow via `workflow_dispatch` with version `0.0.12` (main is already at 0.0.12, no tag exists), or regenerate the release PR.
